### PR TITLE
Add splibnoindex type

### DIFF
--- a/datatypes_conf.xml
+++ b/datatypes_conf.xml
@@ -49,6 +49,9 @@
     <datatype extension="splib" type="galaxy.datatypes.proteomics:SPLibNoIndex" display_in_upload="true" />
     <datatype extension="splib" type="galaxy.datatypes.proteomics:SPLib" display_in_upload="true" />
     <datatype extension="sf3" type="galaxy.datatypes.proteomics:Sf3" display_in_upload="true" />
+    <datatype extension="searchgui_zip" type="galaxy.datatypes.binary:Binary" mimetype="application/octet-stream" subclass="True" />
+    <datatype extension="peptideshaker_zip" type="galaxy.datatypes.binary:Binary" mimetype="application/octet-stream" subclass="True" />
+
   </registration>
   <sniffers>
     <sniffer type="galaxy.datatypes.proteomics:MzML"/>

--- a/datatypes_conf.xml
+++ b/datatypes_conf.xml
@@ -46,6 +46,7 @@
     <datatype extension="msp" type="galaxy.datatypes.proteomics:Msp" display_in_upload="true" />
     <datatype extension="ms2" type="galaxy.datatypes.proteomics:Ms2" display_in_upload="true" />
     <datatype extension="hlf" type="galaxy.datatypes.proteomics:XHunterAslFormat" mimetype="application/octet-stream" display_in_upload="true" />
+    <datatype extension="splib" type="galaxy.datatypes.proteomics:SPLibNoIndex" display_in_upload="true" />
     <datatype extension="splib" type="galaxy.datatypes.proteomics:SPLib" display_in_upload="true" />
     <datatype extension="sf3" type="galaxy.datatypes.proteomics:Sf3" display_in_upload="true" />
   </registration>

--- a/datatypes_conf.xml
+++ b/datatypes_conf.xml
@@ -49,9 +49,6 @@
     <datatype extension="splib" type="galaxy.datatypes.proteomics:SPLibNoIndex" display_in_upload="true" />
     <datatype extension="splib" type="galaxy.datatypes.proteomics:SPLib" display_in_upload="true" />
     <datatype extension="sf3" type="galaxy.datatypes.proteomics:Sf3" display_in_upload="true" />
-    <datatype extension="searchgui_zip" type="galaxy.datatypes.binary:Binary" mimetype="application/octet-stream" subclass="True" />
-    <datatype extension="peptideshaker_zip" type="galaxy.datatypes.binary:Binary" mimetype="application/octet-stream" subclass="True" />
-
   </registration>
   <sniffers>
     <sniffer type="galaxy.datatypes.proteomics:MzML"/>

--- a/proteomics.py
+++ b/proteomics.py
@@ -285,6 +285,19 @@ class Msp( Text ):
         with open(filename, 'r') as contents:
             return Msp.next_line_starts_with(contents, "Name:") and Msp.next_line_starts_with(contents, "MW:")
 
+class SPLibNoIndex( Text ):
+    """SPlib without index file """
+    file_ext = "splib"
+
+    def set_peek( self, dataset, is_multi_byte=False ):
+        """Set the peek and blurb text"""
+        if not dataset.dataset.purged:
+            dataset.peek = data.get_file_peek( dataset.file_name, is_multi_byte=is_multi_byte )
+            dataset.blurb = 'Spectral Library without index files'
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
 
 class SPLib( Msp ):
     """SpectraST Spectral Library. Closely related to msp format"""


### PR DESCRIPTION
@bgruening Can you take a look at this PR.  This is how I was thinking to implement the splibnoindex datatype.  I kept the extension as splib even though this overlaps with the other splib.  Hopefully this will not be too bad in practice as users will tend to produce these from tools specifically and then there will be no ambiguity.  If we keep the extension as splib I think galaxy will be able to autodetect the type in uploads right? (even without a sniffer?)
